### PR TITLE
adapt cmd-saslContinue's parameters to 4.4.9+

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -332,6 +332,7 @@ func (socket *mongoSocket) loginSASL(cred Credential) error {
 			Payload:        payload,
 		}
 		start = 0
+		cred.Mechanism = ""
 		err = socket.loginRun(cred.Source, &cmd, &res, func() error {
 			// See the comment on lock for why this is necessary.
 			lock(true)


### PR DESCRIPTION
https://jira.mongodb.org/browse/SERVER-53154
Specify input/output to saslStart command in IDL and config cmd-saslContinue with strict: true